### PR TITLE
fix:servicenetworking

### DIFF
--- a/modules/vpc/network.tf
+++ b/modules/vpc/network.tf
@@ -26,7 +26,5 @@ resource "google_compute_global_address" "apigee_range" {
 resource "google_service_networking_connection" "apigee_vpc_connection" {
   network                 = google_compute_network.apigee_network.id
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = etwork                 = google_compute_network.apigee_network.id
-  service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [ for range in google_compute_global_address.apigee_range : range.name ]
 }

--- a/modules/vpc/network.tf
+++ b/modules/vpc/network.tf
@@ -24,8 +24,9 @@ resource "google_compute_global_address" "apigee_range" {
 }
 
 resource "google_service_networking_connection" "apigee_vpc_connection" {
-  for_each                = local.apigee_envs
   network                 = google_compute_network.apigee_network.id
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.apigee_range[each.key].name]
+  reserved_peering_ranges = etwork                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [ for range in google_compute_global_address.apigee_range : range.name ]
 }


### PR DESCRIPTION
Multiple apigee environments cause the creation attempt of google_service_networking_connection ressources.  This is not allowed/working.
Fix: Use only 1 google_service_networking_connection resource with multiple ranges to peer